### PR TITLE
Parse locale qualifiers + inject language / locale / script tags into generated strings.xml

### DIFF
--- a/app/src/main/kotlin/io/genstrings/sample/MainActivity.kt
+++ b/app/src/main/kotlin/io/genstrings/sample/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.genstrings.sample
 
 import android.app.Activity
+import android.content.res.Resources
 import android.os.Bundle
 import android.os.LocaleList
 import android.widget.TextView
@@ -11,7 +12,11 @@ class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val deviceLocale = LocaleList.getDefault().get(0)
+        // https://stackoverflow.com/questions/4212320/get-the-current-language-in-device
+        // https://medium.com/@hectorricardomendez/how-to-get-the-current-locale-in-android-fc12d8be6242
+        val deviceLocale = Resources.getSystem().configuration.locales.get(0)
+
+        // this isn't very useful; use genstrings_language to see what was actually resolved
         val appLocale = resources.configuration.locales.get(0)
 
         val strings = mapOf(

--- a/plugin/src/main/kotlin/GenstringsPlugin.kt
+++ b/plugin/src/main/kotlin/GenstringsPlugin.kt
@@ -1,6 +1,7 @@
 package io.genstrings
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import io.genstrings.common.AndroidLocaleQualifier
 import io.genstrings.plugin.GenstringsExtension.Companion.registerExtension
 import io.genstrings.task.CreateTemplateTask
 import io.genstrings.task.ProcessStringsYamlToXmlTask
@@ -92,14 +93,14 @@ class GenstringsPlugin : Plugin<Project> {
             }
             val taskName = buildString {
                 append("genstringsTranslate")
-                entry.name.split("-").forEach {
+                AndroidLocaleQualifier.parse(entry.name).toString().split("-").forEach {
                     append(it.cap())
                 }
             }
             target.tasks.register(
                 taskName, TranslateTask::class.java
             ) { task ->
-                task.description = "Generate translations for locale: ${entry.name}"
+                task.description = "Generate translations for ${entry.description}"
                 task.configFile.set(extension.configFile)
                 task.sourceYamlFiles.from(sourceYamlFiles)
                 task.languages.set(language)

--- a/plugin/src/main/kotlin/common/AndroidLocaleQualifier.kt
+++ b/plugin/src/main/kotlin/common/AndroidLocaleQualifier.kt
@@ -1,0 +1,73 @@
+package io.genstrings.common
+
+// https://developer.android.com/guide/topics/resources/providing-resources.html#AlternativeResources
+sealed interface AndroidLocaleQualifier {
+
+    val languageCode: String
+    val script: String?
+        get() = null
+
+    data class Default(
+        override val languageCode: String,
+        val region: String?,
+    ) : AndroidLocaleQualifier {
+
+        override fun toString() = listOfNotNull(
+            languageCode, region
+        ).joinToString("-")
+    }
+
+    data class Bcp47(
+        override val languageCode: String,
+        val subtags: List<String>,
+    ) : AndroidLocaleQualifier {
+
+        // https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.3
+        // simplified implementation check's length but doesn't verify position
+        override val script = subtags.firstOrNull { it.length == 4 }
+
+        override fun toString() = buildList {
+            add(languageCode)
+            addAll(subtags)
+        }.joinToString("-")
+    }
+
+    data class Invalid(
+        val rawLocale: String
+    ) : AndroidLocaleQualifier {
+
+        override val languageCode = rawLocale
+
+        override fun toString() = rawLocale
+    }
+
+    companion object {
+        fun parse(value: String) : AndroidLocaleQualifier {
+            return try {
+                if (value.startsWith("b+")) {
+                    tryParseBcp47Qualifier(value)
+                } else {
+                    tryParseDefaultQualifier(value)
+                }
+            } catch (ex: Exception) {
+                Invalid(rawLocale = value)
+            }
+        }
+
+        private fun tryParseBcp47Qualifier(value: String): Bcp47 {
+            val components = value.substringAfter("b+").split("+")
+            return Bcp47(
+                languageCode = components[0],
+                subtags = components.drop(1),
+            )
+        }
+
+        private fun tryParseDefaultQualifier(value: String): Default {
+            val components = value.split("-r")
+            return Default(
+                languageCode = components[0],
+                region = components.getOrNull(1),
+            )
+        }
+    }
+}

--- a/plugin/src/main/kotlin/model/Language.kt
+++ b/plugin/src/main/kotlin/model/Language.kt
@@ -1,9 +1,14 @@
 package io.genstrings.model
 
+import io.genstrings.common.AndroidLocaleQualifier
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class Language(
     val name: String,
     val locale: String,
-) : java.io.Serializable
+) : java.io.Serializable {
+
+    val parsedLocale: AndroidLocaleQualifier
+        get() = AndroidLocaleQualifier.parse(locale)
+}

--- a/plugin/src/main/kotlin/translator/PromptBuilder.kt
+++ b/plugin/src/main/kotlin/translator/PromptBuilder.kt
@@ -24,7 +24,7 @@ class DefaultPromptBuilder : PromptBuilder {
             You are an AI assistant that translates string resources for a mobile app.
             
             Target language: ${language.name}
-            Locale: ${language.locale}
+            Locale: ${language.parsedLocale}
         """.trimIndent())
 
         if (appContext != null) {


### PR DESCRIPTION
Added simple parsing for Android locale qualifiers as described in:
[Provide Alternative Resources](https://developer.android.com/guide/topics/resources/providing-resources.html#AlternativeResources)

This does not currently verify that the qualifiers are in the proper format, however, it does a reasonable job of extracting the base language code (i.e. `zh`) and the script (i.e. `Hant`) if any.

The following fields are now injected into every generated `strings.xml` file:
* `genstrings_language`: The name of the language as specified in the plugin configuration (i.e. "Chinese (Traditional Han)"
* `genstrings_language_code`: The 2 or 3 digit language code, i.e. `zh`
* `genstrings_locale_tag`: The full, parsed qualifier as specified in the plugin configuration (i.e. `zh-Hant`)
* `genstrings_script`: The 4-character script parsed from the qualifier (i.e. `Hant`)

These injected fields are intended to be a reliable way to determine which `strings.xml` was actually displayed by the system at runtime.